### PR TITLE
Prevent shlex from choking on files with quotes in name

### DIFF
--- a/redhat_access_insights/data_collector.py
+++ b/redhat_access_insights/data_collector.py
@@ -294,7 +294,7 @@ class DataCollector(object):
             return
         logger.debug("Copying %s to %s with filters %s", path, full_path, str(patterns))
 
-        cmd = "/bin/sed -rf %s %s" % (constants.default_sed_file, path)
+        cmd = "/bin/sed -rf %s %s" % (constants.default_sed_file, path.replace("'", ""))
         sedcmd = Popen(shlex.split(cmd.encode('utf-8')),
                        stdout=PIPE)
 


### PR DESCRIPTION
Apostrophes are not handled gracefully by shlex if there isn't a corresponding closing apostrophe.  In my case, I had a network interface that included an apostrophe, causing the uploader to fail.
