### PR TITLE
Don't create archive from root dir

### DIFF
--- a/redhat_access_insights/archive.py
+++ b/redhat_access_insights/archive.py
@@ -117,7 +117,7 @@ class InsightsArchive(object):
         ext = "" if self.compressor == "none" else ".%s" % self.compressor
         tar_file_name = tar_file_name + ".tar" + ext
         logger.debug("Tar File: " + tar_file_name)
-        subprocess.call(shlex.split("tar c%sf %s %s" % (
+        subprocess.call(shlex.split("tar c%sf %s -C %s ." % (
             self.get_compression_flag(self.compressor),
             tar_file_name,
             self.tmp_dir)), stderr=subprocess.PIPE)


### PR DESCRIPTION
Without this fix, archives created use the path `/var/tmp/<tmpdir>/...`.
