### PR TITLE
Using magic to specify mime type for uploads

### DIFF
--- a/redhat_access_insights/connection.py
+++ b/redhat_access_insights/connection.py
@@ -477,7 +477,10 @@ class InsightsConnection(object):
         Do an HTTPS Upload of the archive
         """
         file_name = os.path.basename(data_collected)
-        files = {'file': (file_name, open(data_collected, 'rb'), 'application/x-gzip')}
+        import magic
+        m = magic.open(magic.MAGIC_MIME_TYPE)
+        m.load()
+        files = {'file': (file_name, open(data_collected, 'rb'), m.file(data_collected))}
 
         upload_url = self.upload_url + '/' + generate_machine_id()
         logger.debug("Uploading %s to %s", data_collected, upload_url)


### PR DESCRIPTION
This change uses the magic library to set the mime type for the report upload file. This improves the support for multiple compression types.
