### PR TITLE
no-upload option should "just work"

### DIFF
--- a/redhat_access_insights/__init__.py
+++ b/redhat_access_insights/__init__.py
@@ -177,7 +177,7 @@ def collect_data_and_upload(config, options, rc=0):
     dc = DataCollector(archive)
 
     # register the exit handler here to delete the archive
-    atexit.register(handle_exit, archive, options.keep_archive)
+    atexit.register(handle_exit, archive, options.keep_archive or options.no_upload)
 
     stdin_config = json.load(sys.stdin) if options.from_stdin else {}
 
@@ -228,7 +228,7 @@ def collect_data_and_upload(config, options, rc=0):
                                      constants.default_log_file)
                         rc = 1
 
-            if not obfuscate and not options.keep_archive:
+            if (not obfuscate and not options.keep_archive) or options.no_upload:
                 dc.archive.delete_tmp_dir()
             else:
                 if obfuscate:
@@ -506,7 +506,7 @@ def handle_startup(options, config):
 
     # Set offline mode for OSP use
     offline_mode = False
-    if options.offline and options.from_stdin:
+    if (options.offline and options.from_stdin) or options.no_upload:
         offline_mode = True
 
     # First startup, no .registered or .unregistered


### PR DESCRIPTION
When I was trying to get a test archive for development purposes, I tried to use the `--no-upload` option, but I got registration errors, and the archive would be deleted before I could pull it out of the temp folder.  I _could_ have used the `--keep-archive` option, but I feel like the `--no-upload` option should work without any other options specified.
