### PR TITLE
alter handling of container_fs so that _expand_paths works correctly

### DIFF
--- a/redhat_access_insights/data_collector.py
+++ b/redhat_access_insights/data_collector.py
@@ -385,7 +385,7 @@ class DataCollector(object):
 
 
         if container_fs:
-            paths_on_disk = os.paths_to_collect.join(container_fs, paths_to_collect.lstrip('/'))
+            paths_on_disk = os.path.join(container_fs, paths_to_collect.lstrip('/'))
         else:
             paths_on_disk = paths_to_collect
 

--- a/redhat_access_insights/data_collector.py
+++ b/redhat_access_insights/data_collector.py
@@ -312,29 +312,30 @@ class DataCollector(object):
         full_path = self.archive.get_full_archive_path('/branch_info')
         write_file_with_text(full_path, json.dumps(branch_info))
 
-    def _copy_file_with_pattern(self, path, patterns, exclude, container_fs):
+    def _copy_file_with_pattern(self, path_on_disk, patterns, exclude, container_fs):
         """
         Copy file, selecting only lines we are interested in
         """
-        full_path = self.archive.get_full_archive_path(path)
 
-        # append container filesystem path to filename
         if container_fs:
-            if container_fs.endswith('/'):
-                container_fs = container_fs.rstrip('/')
-            path = os.path.realpath(container_fs) + path
+            # reconstruct the path_to_collect by stripping off the container
+            path_to_collect = '/' + os.path.relpath(path_on_disk, container_fs)
+        else:
+            path_to_collect = path_on_disk
 
-        if not os.path.isfile(path):
-            logger.debug("File %s does not exist", path)
+        path_in_archive = self.archive.get_full_archive_path(path_to_collect)
+
+        if not os.path.isfile(path_on_disk):
+            logger.debug("File %s does not exist", path_on_disk)
             return
-        logger.debug("Copying %s to %s with filters %s", path, full_path, str(patterns))
+        logger.debug("Copying %s to %s with filters %s", path_on_disk, path_in_archive, str(patterns))
 
         cmd = []
         # shlex.split doesn't handle special characters well
         cmd.append("/bin/sed".encode('utf-8'))
         cmd.append("-rf".encode('utf-8'))
         cmd.append(constants.default_sed_file.encode('utf-8'))
-        cmd.append(path.encode('utf8'))
+        cmd.append(path_on_disk.encode('utf8'))
         sedcmd = Popen(cmd,
                        stdout=PIPE)
 
@@ -371,22 +372,32 @@ class DataCollector(object):
         if patterns is None and exclude is None:
             output = sedcmd.communicate()[0]
 
-        write_file_with_text(full_path, output.decode('utf-8', 'ignore').strip())
+        write_file_with_text(path_in_archive, output.decode('utf-8', 'ignore').strip())
 
-    def copy_file_with_pattern(self, path, patterns, exclude, container_fs):
+    def copy_file_with_pattern(self, paths_to_collect, patterns, exclude, container_fs):
         """
         Copy a single file or regex, creating the necessary directories
         But grepping for pattern(s)
+
+        paths_to_collect is the path pattern as specified in the uploader.json file
+        container_fs is None or the location of the container (as a directory tree)
         """
-        if "*" in path:
-            paths = _expand_paths(path)
-            if not paths:
-                logger.debug("Could not expand %s", path)
-                return
-            for path in paths:
-                self._copy_file_with_pattern(path, patterns, exclude, container_fs)
+
+
+        if container_fs:
+            paths_on_disk = os.paths_to_collect.join(container_fs, paths_to_collect.lstrip('/'))
         else:
-            self._copy_file_with_pattern(path, patterns, exclude, container_fs)
+            paths_on_disk = paths_to_collect
+
+        if "*" in paths_to_collect:
+            paths = _expand_paths(paths_on_disk)
+            if not paths:
+                logger.debug("Could not expand %s", paths_on_disk)
+                return
+            for path_on_disk in paths:
+                self._copy_file_with_pattern(path_on_disk, patterns, exclude, container_fs)
+        else:
+            self._copy_file_with_pattern(paths_on_disk, patterns, exclude, container_fs)
 
     def done(self, config, rm_conf):
         """


### PR DESCRIPTION
For paths with regexs in them, container mode is failing to collect files that match the pattern.   This is because _expand_files, which expands the regex based on what files are actually on the disk, is run before container_fs and the path pattern are combined.

This patch combines container_fs and the path from the json file earlier (just before _expand_files).  It then must strip off the container_fs later before determining the path in the archive.
