### PR TITLE
optional transfer to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,6 @@ RUN yum install -y tar
 
 RUN yum clean -y all
 
-
-# We don't want to copy everything from the source directory
-#   and Docker COPY won't copy directories listed on the command line
-#   only their contents (stupid),
-#   so we copy each _directory_ individually and then all the _files_ together
 COPY docs /src/insights-client/docs
 COPY etc /src/insights-client/etc
 COPY redhat_access_insights /src/insights-client/redhat_access_insights

--- a/redhat_access_insights/constants.py
+++ b/redhat_access_insights/constants.py
@@ -25,3 +25,4 @@ class InsightsConstants(object):
     lastupload_file = default_conf_dir + '.lastupload'
     pub_gpg_path = default_conf_dir + 'redhattools.pub.gpg'
     machine_id_file = default_conf_dir + 'machine-id'
+    docker_image_name = None


### PR DESCRIPTION
   We now can declare the name of the image to transfer into either on the command line, or
   in the config, or in the constants.  The default for now is no image, and no transfer.
