### PR TITLE
handle failure to mount a container or image better

### DIFF
--- a/redhat_access_insights/__init__.py
+++ b/redhat_access_insights/__init__.py
@@ -239,7 +239,7 @@ def collect_data_and_upload(config, options, rc=0):
                     container_fs = container_connection.get_fs()
                 else:
                     logger.error('Could not open image for analysis: %s' % t['name'])
-                    return 1
+                    continue
 
             elif t['type'] == "docker_container":
                 container_connection = containers.open_container(t['name'])
@@ -247,7 +247,7 @@ def collect_data_and_upload(config, options, rc=0):
                     container_fs = container_connection.get_fs()
                 else:
                     logger.error('Could not open container for analysis: %s' % t['name'])
-                    return 1
+                    continue
 
             elif t['type'] == "host":
                 container_connection = None
@@ -255,7 +255,7 @@ def collect_data_and_upload(config, options, rc=0):
 
             else:
                 logger.error("Unexpected analysis target: %s" % t['type'])
-                return 1
+                continue
 
             collection_start = time.clock()
 

--- a/redhat_access_insights/containers/__init__.py
+++ b/redhat_access_insights/containers/__init__.py
@@ -162,7 +162,7 @@ if HaveDocker:
                 return AtomicTemporaryMountPoint(image_id, mount_point)
             else:
                 logger.error('Could not mount Image Id %s On %s' % (image_id, mount_point))
-                shutil.rmtree(self.mount_point, ignore_errors=True)
+                shutil.rmtree(mount_point, ignore_errors=True)
                 return None
 
         def open_container(container_id):
@@ -172,7 +172,7 @@ if HaveDocker:
                 return AtomicTemporaryMountPoint(container_id, mount_point)
             else:
                 logger.error('Could not mount Container Id %s On %s' % (container_id, mount_point))
-                shutil.rmtree(self.mount_point, ignore_errors=True)
+                shutil.rmtree(mount_point, ignore_errors=True)
                 return None
 
     else:
@@ -212,7 +212,7 @@ if HaveDocker:
                     return DockerTemporaryMountPoint(client, image_id, mount_point, cid)
                 else:
                     logger.error('Could not mount Image Id %s On %s' % (image_id, mount_point))
-                    shutil.rmtree(self.mount_point, ignore_errors=True)
+                    shutil.rmtree(mount_point, ignore_errors=True)
                     return None
 
             else:
@@ -240,7 +240,7 @@ if HaveDocker:
                         return DockerTemporaryMountPoint(client, container_id, mount_point, cid)
                     else:
                         logger.error('Could not mount Container Id %s On %s' % (container_id, mount_point))
-                        shutil.rmtree(self.mount_point, ignore_errors=True)
+                        shutil.rmtree(mount_point, ignore_errors=True)
                         return None
 
                 else:


### PR DESCRIPTION
```
first correct a bug in the error handling where 'self' is misused
next don't die if you fail to mount a container, just go on
```
