### PR TITLE
Scrap docker py

### DIFF
--- a/redhat_access_insights/containers/__init__.py
+++ b/redhat_access_insights/containers/__init__.py
@@ -89,7 +89,7 @@ if HaveDocker:
         return HaveAtomic
 
     def use_atomic_mount():
-        return HaveAtomicMount
+        return HaveAtomicMount and not InsightsClient.options.run_here
 
     def pull_image(image):
         return runcommand(shlex.split("docker pull") + [image])

--- a/redhat_access_insights/containers/__init__.py
+++ b/redhat_access_insights/containers/__init__.py
@@ -120,9 +120,9 @@ if HaveDocker:
                 targets.append({'type': 'docker_container', 'name': d['Id']})
         return targets
 
-    def run_in_container(options):
+    def run_in_container():
 
-        if options.from_file:
+        if InsightsClient.options.from_file:
             logger.error('--from-file is incompatible with transfering to a container.')
             return 1
 
@@ -224,7 +224,7 @@ if HaveDocker:
                 return AtomicTemporaryMountPoint(image_id, mount_point)
             else:
                 logger.error('Could not mount Image Id %s On %s' % (image_id, mount_point))
-                shutil.rmtree(self.mount_point, ignore_errors=True)
+                shutil.rmtree(mount_point, ignore_errors=True)
                 return None
 
         else:
@@ -242,7 +242,7 @@ if HaveDocker:
                     return DockerTemporaryMountPoint(client, image_id, mount_point, cid)
                 else:
                     logger.error('Could not mount Image Id %s On %s' % (image_id, mount_point))
-                    shutil.rmtree(self.mount_point, ignore_errors=True)
+                    shutil.rmtree(mount_point, ignore_errors=True)
                     return None
 
             else:
@@ -297,8 +297,8 @@ else:
                      (HaveDockerException if HaveDockerException else ''))
         return False
 
-    def run_in_container(options):
-        logger.error('Could not connect to docker to examine image %s' % options.analyse_docker_image)
+    def run_in_container():
+        logger.debug('Could not connect to docker to transfer into a container')
         logger.error('Docker is either not installed or not accessable: %s' %
                      (HaveDockerException if HaveDockerException else ''))
         return 1


### PR DESCRIPTION
This gets rid of all dependencies on python-docker-py, the python docker client package.  We don't want to force users to install _both_ docker and python-docker-py if we can help it.  The benifit we were getting from using python-docker-py was not worth the headaches that will be caused by users not knowing that they need to install it.
