### PR TITLE
Use __name__ for logger names

### DIFF
--- a/insights_client/__init__.py
+++ b/insights_client/__init__.py
@@ -44,10 +44,9 @@ from containers import (open_image,
 from client_config import InsightsClient, set_up_options, parse_config_file
 
 __author__ = 'Jeremy Crafts <jcrafts@redhat.com>, Dan Varga <dvarga@redhat.com>'
-
 LOG_FORMAT = ("%(asctime)s %(levelname)s %(message)s")
 APP_NAME = constants.app_name
-logger = logging.getLogger(APP_NAME)
+logger = logging.getLogger(__name__)
 
 
 def set_up_logging():

--- a/insights_client/archive.py
+++ b/insights_client/archive.py
@@ -9,10 +9,9 @@ import subprocess
 import shlex
 import logging
 from utilities import determine_hostname, _expand_paths, write_data_to_file
-from constants import InsightsConstants as constants
 from insights_spec import InsightsFile, InsightsCommand
 
-logger = logging.getLogger(constants.app_name)
+logger = logging.getLogger(__name__)
 
 
 class InsightsArchive(object):

--- a/insights_client/auto_config.py
+++ b/insights_client/auto_config.py
@@ -9,7 +9,7 @@ from cert_auth import rhsmCertificate
 from connection import InsightsConnection
 from client_config import InsightsClient
 
-logger = logging.getLogger(constants.app_name)
+logger = logging.getLogger(__name__)
 APP_NAME = constants.app_name
 
 

--- a/insights_client/cert_auth.py
+++ b/insights_client/cert_auth.py
@@ -3,9 +3,8 @@ Module to interact with Satellite Based Certificates
 """
 import os
 import logging
-from constants import InsightsConstants as constants
 
-logger = logging.getLogger(constants.app_name)
+logger = logging.getLogger(__name__)
 
 # RHSM and Subscription Manager
 RHSM_CONFIG = None

--- a/insights_client/client_config.py
+++ b/insights_client/client_config.py
@@ -8,7 +8,7 @@ import ConfigParser
 from constants import InsightsConstants as constants
 
 APP_NAME = constants.app_name
-logger = logging.getLogger(APP_NAME)
+logger = logging.getLogger(__name__)
 
 
 class InsightsClient:

--- a/insights_client/collection_rules.py
+++ b/insights_client/collection_rules.py
@@ -13,7 +13,7 @@ from constants import InsightsConstants as constants
 from client_config import InsightsClient
 
 APP_NAME = constants.app_name
-logger = logging.getLogger(APP_NAME)
+logger = logging.getLogger(__name__)
 
 
 class InsightsConfig(object):

--- a/insights_client/connection.py
+++ b/insights_client/connection.py
@@ -24,7 +24,7 @@ warnings.simplefilter('ignore')
 
 APP_NAME = constants.app_name
 
-logger = logging.getLogger(APP_NAME)
+logger = logging.getLogger(__name__)
 """
 urllib3's logging is chatty
 """

--- a/insights_client/containers/__init__.py
+++ b/insights_client/containers/__init__.py
@@ -14,7 +14,7 @@ import subprocess
 from insights_client.constants import InsightsConstants as constants
 
 APP_NAME = constants.app_name
-logger = logging.getLogger(APP_NAME)
+logger = logging.getLogger(__name__)
 
 
 def run_command_very_quietly(cmdline):

--- a/insights_client/data_collector.py
+++ b/insights_client/data_collector.py
@@ -16,7 +16,8 @@ from insights_spec import InsightsFile, InsightsCommand
 from client_config import InsightsClient
 
 APP_NAME = constants.app_name
-logger = logging.getLogger(APP_NAME)
+logger = logging.getLogger(__name__)
+
 # python 2.7
 SOSCLEANER_LOGGER = logging.getLogger('soscleaner')
 SOSCLEANER_LOGGER.setLevel(logging.ERROR)

--- a/insights_client/insights_spec.py
+++ b/insights_client/insights_spec.py
@@ -9,7 +9,7 @@ from tempfile import NamedTemporaryFile
 from utilities import determine_hostname
 from constants import InsightsConstants as constants
 
-logger = logging.getLogger(constants.app_name)
+logger = logging.getLogger(__name__)
 
 
 class InsightsSpec(object):

--- a/insights_client/schedule.py
+++ b/insights_client/schedule.py
@@ -9,7 +9,7 @@ from constants import InsightsConstants as constants
 CRON_DAILY = '/etc/cron.daily/'
 CRON_WEEKLY = '/etc/cron.weekly/'
 APP_NAME = constants.app_name
-logger = logging.getLogger(APP_NAME)
+logger = logging.getLogger(__name__)
 
 
 class InsightsSchedule(object):

--- a/insights_client/support.py
+++ b/insights_client/support.py
@@ -12,7 +12,7 @@ from connection import InsightsConnection
 from client_config import InsightsClient
 
 APP_NAME = constants.app_name
-logger = logging.getLogger(APP_NAME)
+logger = logging.getLogger(__name__)
 
 
 def registration_check():

--- a/insights_client/utilities.py
+++ b/insights_client/utilities.py
@@ -11,7 +11,7 @@ import shlex
 from subprocess import Popen, PIPE, STDOUT
 from constants import InsightsConstants as constants
 
-logger = logging.getLogger(constants.app_name)
+logger = logging.getLogger(__name__)
 
 
 def determine_hostname(display_name=None):


### PR DESCRIPTION
Use the modules __name__ in the logging.getLogger() calls
based on the recomendation from the logging.Logger docs
at https://docs.python.org/2/library/logging.html#logger-objects.

This allows per module logger configuration. For example, all loggers
could be set to DEBUG while the 'insights_client.connection' logger
is set to INFO.

This also makes log formats like "%(asctime)s %(levelname)s %(name)s %(funcName)s:%(lineno)d - %(message)s"
more useful for debugging.