### PR TITLE
Make _test_openssl case insensitive

### DIFF
--- a/insights_client/connection.py
+++ b/insights_client/connection.py
@@ -358,7 +358,7 @@ class InsightsConnection(object):
                 sys.exit(1)
             sock.send(connect_str)
             res = sock.recv(4096)
-            if '200 Connection established' not in res:
+            if '200 connection established' not in res.lower():
                 logger.error('Failed to connect to %s. Invalid hostname.', self.base_url)
                 sys.exit(1)
         else:


### PR DESCRIPTION
Some proxies respond with "200 Connection Established" and not "200 Connection established". This change should makes the _test_openssl function case insensitive while checking the output.