### PR TITLE
Update connection.py to connect to port 443

### DIFF
--- a/insights_client/connection.py
+++ b/insights_client/connection.py
@@ -234,7 +234,7 @@ class InsightsConnection(object):
 
         # handle endpoint validation
         if self.proxies:
-            connect_str = 'CONNECT {0} HTTP/1.0\r\n'.format(hostname[0])
+            connect_str = 'CONNECT {0}:443 HTTP/1.0\r\n'.format(hostname[0])
             if self.proxy_auth:
                 connect_str += 'Proxy-Authorization: {0}\r\n'.format(self.proxy_auth)
             connect_str += '\r\n'


### PR DESCRIPTION
Connect request for the SSL chain check needs to be sent to port 443 as some proxies like "Zscaler" will forward the request to port 80 instead, which breaks the connection.

The proposed change sends request to port 443 for the configured api hostname